### PR TITLE
Fix docker test network issue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./docker/app/Dockerfile
     ports:
       - "9000:9000"
-    command: yarn start
+    command: yarn start-tls
 
   wdio:
     build: 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config jest.conf.js",
     "jest:update": "yarn run jest -- --updateSnapshot",
     "start": "yarn run webapp:dev --",
-    "start-tls": "yarn run webapp:dev -- --env.tls",
+    "start-tls": "yarn run webapp:dev --env tls",
     "pretest": "yarn run lint",
     "test": "yarn run jest --",
     "test-ci": "yarn run lint && yarn run jest:update --",

--- a/src/test/javascript/spec/screenshot.ts
+++ b/src/test/javascript/spec/screenshot.ts
@@ -2,7 +2,7 @@ import { browser, $, expect } from '@wdio/globals';
 import { WdioCheckElementMethodOptions } from '@wdio/visual-service/dist/types';
 import * as path from 'path';
 
-// const BASE_URL = 'http://chrome:9000';
+const BASE_URL = 'https://app:9000';
 // const DATABASE_EMULATOR_URL = 'http://127.0.0.1:9095/?ns=mock-data';
 
 describe('Screenshot Tests', () => {
@@ -89,9 +89,9 @@ describe('Screenshot Tests', () => {
   });
 
   it('should compare gene list', async () => {
-    await browser.url('https://google.com');
-    await browser.pause(180000);
-    // await browser.url(`${BASE_URL}/curation`);
+    // await browser.url('https://google.com');
+    await browser.url(`${BASE_URL}/curation`);
+    await browser.pause(6000);
 
     const geneList = await $('#gene-list');
     await geneList.waitForDisplayed();

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -86,6 +86,7 @@ module.exports = async options =>
         },
       ],
       server: options.tls ? 'https' : 'http',
+      allowedHosts: 'all',
       historyApiFallback: true,
     },
     stats: process.env.JHI_DISABLE_WEBPACK_LOGS ? 'none' : options.stats,


### PR DESCRIPTION
- Chrome prevents using http. We need to start a https server
- In docker services, the network is called using the service name. We need to allow all hosts to access the dev server